### PR TITLE
fix(translate): preserve qualified types in {Trait for Type}

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Fixed
+- **`unwrap_braces` preserves qualified implementing types in `{Trait for Type}`**
+  (issue #9): previously all implementing types were stripped, causing different
+  `From` impls in the same module (e.g., `LookupTable::from` vs
+  `NafLookupTable5::from`) to normalize to the same string and produce false
+  `is-disabled: false`. Now types containing `::` are preserved; bare types
+  (generic params, primitives) are still stripped to avoid Charon numbering
+  mismatches.
+
 ### Changed
 - **CI: auto-tag uses `RELEASE_PAT`** so pushed tags trigger the release workflow
   (aligns with probe-lean; previously tags pushed by `GITHUB_TOKEN` were silently

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -292,8 +292,10 @@ strategy, it is excluded from later ones.
 Matches via the `rust-qualified-name` extension field on Rust atoms (derived
 from Charon LLBC), joined with the `rust_name` field in `functions.json`.
 Names are normalized: lifetime parameters, reference markers, generic
-parameters (at any nesting depth), `impl` prefixes, and `for Type` suffixes
-in trait-impl brace segments are all stripped before comparison.
+parameters (at any nesting depth), and `impl` prefixes in trait-impl brace
+segments are stripped. In `{Trait for Type}` segments, bare types (generic
+parameters, primitives) are stripped, but fully qualified types (containing
+`::`) are preserved to distinguish different trait implementations.
 
 **Requires:** `probe-rust extract --with-charon` for the Rust atoms.
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -157,23 +157,27 @@ could be matched exactly.
 cargo test
 ```
 
-29 tests passing (translate module):
+33 tests passing (translate module):
 - `test_normalize_rust_name` -- brace unwrapping for simple `{Type}` segments
 - `test_normalize_strips_generics_and_refs` -- lifetime/reference removal
 - `test_normalize_simple_brace_unwrap` -- minimal `{Type}` unwrapping
 - `test_normalize_no_braces_passthrough` -- plain paths unchanged
 - `test_normalize_single_level_generics` -- `Vec<u8>` → `Vec`
 - `test_normalize_nested_generics` -- `From<SpecificServiceId<KIND>>` → `From`
-- `test_normalize_impl_and_for_type_match` -- `{impl Trait}` and `{Trait for Type}` produce same output
+- `test_normalize_impl_and_bare_for_type_match` -- `{impl Trait}` and `{Trait for BareType}` produce same output
 - `test_normalize_impl_stripped` -- `{impl Trait}` prefix removal
-- `test_normalize_for_type_stripped` -- `{Trait for Type}` suffix removal
+- `test_normalize_for_bare_type_stripped` -- `{Trait for BareType}` bare type stripped
+- `test_normalize_for_qualified_type_preserved` -- `{Trait for mod::Type}` preserves type
+- `test_normalize_different_from_impls_are_distinct` -- issue #9 regression
 - `test_normalize_rust_name_deterministic_strips_generics` -- behavioral contract: no `<`/`>` in output
 - `test_normalize_rust_name_strips_refs_and_lifetimes` -- behavioral contract: no `&`/`'` in output
 - `test_normalize_rust_name_identity_for_simple_names` -- `foo` → `foo`
 - `test_unwrap_braces_multiple_segments` -- `{impl A}::{B for C}::m` → `A::B::m`
 - `test_unwrap_braces_no_braces` -- passthrough
 - `test_unwrap_braces_impl_without_for` -- `{impl Trait}` → `Trait`
-- `test_unwrap_braces_for_without_impl` -- `{Trait for Type}` → `Trait`
+- `test_unwrap_braces_for_without_impl` -- `{Trait for BareType}` → `Trait`
+- `test_unwrap_braces_for_qualified_type_kept` -- `{Trait for mod::Type}` → `Trait::mod::Type`
+- `test_unwrap_braces_for_empty_type` -- `{Trait for }` → `Trait`
 - `test_line_range_parse` / `test_line_range_parse_invalid` -- "L292-L325" parsing
 - `test_line_range_overlap` / `test_line_range_no_overlap` -- range geometry
 - `test_strategy_file_display_name` -- strategy 2 matching

--- a/src/translate.rs
+++ b/src/translate.rs
@@ -19,8 +19,12 @@ fn normalize_source_path(p: &str) -> &str {
 
 static RE_REF: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"&'?\w*\s*").expect("valid regex"));
 /// Unwrap `{…}` segments in a Rust qualified name, normalizing trait-impl
-/// notation so that both Charon's `{impl Trait}` shorthand and the expanded
-/// `{Trait<Params> for Type}` form reduce to just the trait path.
+/// notation. Charon's `{impl Trait}` shorthand reduces to `Trait`. The
+/// expanded `{Trait<Params> for Type}` form preserves the implementing type
+/// only when it is fully qualified (contains `::`), producing
+/// `Trait<Params>::Type`. Bare names (generic parameters like `T`/`T0`,
+/// primitives like `u8`) are stripped to avoid mismatches from Charon's
+/// type-parameter numbering.
 fn unwrap_braces(s: &str) -> String {
     let mut result = String::with_capacity(s.len());
     let mut chars = s.chars().peekable();
@@ -45,11 +49,18 @@ fn unwrap_braces(s: &str) -> String {
                 }
             }
             let inner = content.strip_prefix("impl ").unwrap_or(&content);
-            let inner = match inner.find(" for ") {
-                Some(idx) => &inner[..idx],
-                None => inner,
-            };
-            result.push_str(inner);
+            match inner.find(" for ") {
+                Some(idx) => {
+                    let trait_part = &inner[..idx];
+                    let type_part = inner[idx + 5..].trim();
+                    result.push_str(trait_part);
+                    if !type_part.is_empty() && type_part.contains("::") {
+                        result.push_str("::");
+                        result.push_str(type_part);
+                    }
+                }
+                None => result.push_str(inner),
+            }
         } else {
             result.push(ch);
         }
@@ -186,6 +197,16 @@ fn extract_base_name(display_name: &str) -> &str {
     display_name.rsplit("::").next().unwrap_or(display_name)
 }
 
+/// Match Rust atoms to Lean translations via normalized `rust-qualified-name`.
+///
+/// `normalize_rust_name` preserves the implementing type in `{Trait for Type}`
+/// segments only when the type is fully qualified (contains `::`), e.g.
+/// `{From for my_crate::MyType}` → `From::my_crate::MyType`. Bare types
+/// (generic parameters like `T`/`T0`, primitives like `u8`) are stripped to
+/// avoid mismatches from Charon's type-parameter numbering. This means
+/// `{impl From}` and `{From for u8}` normalize identically (both → `From`),
+/// while `{From for crate::LookupTable}` and `{From for crate::NafTable}`
+/// remain distinct.
 fn strategy_rust_qualified_name(
     rust_data: &BTreeMap<String, Atom>,
     lean_data: &BTreeMap<String, Atom>,
@@ -600,7 +621,9 @@ mod tests {
     }
 
     #[test]
-    fn test_normalize_impl_and_for_type_match() {
+    fn test_normalize_impl_and_bare_for_type_match() {
+        // {impl Trait} and {Trait for BareType} both strip the type (bare = no `::`)
+        // so they normalize identically.
         let atom = normalize_rust_name("libsignal_core::address::{impl core::convert::From}::from");
         let fj = normalize_rust_name(
             "libsignal_core::address::{core::convert::From<libsignal_core::address::ServiceIdKind> for u8}::from",
@@ -617,10 +640,20 @@ mod tests {
     }
 
     #[test]
-    fn test_normalize_for_type_stripped() {
+    fn test_normalize_for_bare_type_stripped() {
+        // Bare types (no `::`) are stripped to avoid generic-parameter mismatches.
         assert_eq!(
             normalize_rust_name("path::{core::convert::From<T> for u8}::method"),
             "path::core::convert::From::method"
+        );
+    }
+
+    #[test]
+    fn test_normalize_for_qualified_type_preserved() {
+        // Fully qualified types (with `::`) are preserved to distinguish impls.
+        assert_eq!(
+            normalize_rust_name("path::{core::convert::From<T> for my::module::MyType}::method"),
+            "path::core::convert::From::my::module::MyType::method"
         );
     }
 
@@ -644,6 +677,39 @@ mod tests {
     #[test]
     fn test_unwrap_braces_for_without_impl() {
         assert_eq!(unwrap_braces("{Trait for Type}"), "Trait");
+    }
+
+    #[test]
+    fn test_unwrap_braces_for_qualified_type_kept() {
+        assert_eq!(
+            unwrap_braces("{Trait for my::module::Type}"),
+            "Trait::my::module::Type"
+        );
+    }
+
+    #[test]
+    fn test_unwrap_braces_for_empty_type() {
+        assert_eq!(unwrap_braces("{Trait for }"), "Trait");
+    }
+
+    // -- Regression test for issue #9: different From impls must not collide --
+
+    #[test]
+    fn test_normalize_different_from_impls_are_distinct() {
+        let lookup = normalize_rust_name(
+            "curve25519_dalek::window::{core::convert::From<&'a \
+             (curve25519_dalek::edwards::EdwardsPoint)> for \
+             curve25519_dalek::window::LookupTable<curve25519_dalek::backend::\
+             serial::u64::field::FieldElement51>}::from",
+        );
+        let naf = normalize_rust_name(
+            "curve25519_dalek::window::{core::convert::From<&'0 \
+             (curve25519_dalek::edwards::EdwardsPoint)> for \
+             curve25519_dalek::window::NafLookupTable5}::from",
+        );
+        assert_ne!(lookup, naf, "different From impls must not collide");
+        assert!(lookup.contains("LookupTable"));
+        assert!(naf.contains("NafLookupTable5"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Fix `unwrap_braces` to preserve the implementing type in `{Trait for Type}` segments when the type is fully qualified (contains `::`). Bare types (generic params like `T`, primitives like `u8`) are still stripped to avoid Charon's type-parameter numbering mismatches.
- Prevents false `is-disabled: false` on functions like `NafLookupTable5::from` that share a trait with `LookupTable::from` in the same module but are not in `functions.json`.
- Adds regression test and updates docs.

Closes #9

## Test plan

- [x] `cargo test` passes (115 unit + 4 integration tests)
- [x] New regression test `test_normalize_different_from_impls_are_distinct` verifies the fix
- [x] Existing tests updated to reflect new behavior (`test_normalize_impl_and_bare_for_type_match`, `test_normalize_for_bare_type_stripped`)
- [x] New edge-case tests: `test_normalize_for_qualified_type_preserved`, `test_unwrap_braces_for_qualified_type_kept`, `test_unwrap_braces_for_empty_type`

Made with [Cursor](https://cursor.com)