### PR TITLE
fix(ci): check out probe repo for path dependency resolution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - uses: actions/checkout@v6
+        with:
+          repository: Beneficial-AI-Foundation/probe
+          path: ../probe
+
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -55,6 +60,11 @@ jobs:
     needs: [fmt, clippy]
     steps:
       - uses: actions/checkout@v6
+
+      - uses: actions/checkout@v6
+        with:
+          repository: Beneficial-AI-Foundation/probe
+          path: ../probe
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
## Summary

- CI was failing because `Cargo.toml` uses `[patch."https://github.com/Beneficial-AI-Foundation/probe"] probe = { path = "../probe" }` but the workflow only checked out the `probe-aeneas` repo itself
- Add `actions/checkout` steps for the `probe` repo at `../probe` in the `clippy` and `test` jobs (matching probe-verus CI layout)

## Test plan

- [ ] CI passes on this PR (clippy + test jobs can now resolve the `probe` path dependency)

Made with [Cursor](https://cursor.com)